### PR TITLE
split overlay layer and add all input device

### DIFF
--- a/examples/layer-surface.c
+++ b/examples/layer-surface.c
@@ -42,7 +42,7 @@ EGLConfig egl_conf;
 EGLSurface egl_surface;
 EGLContext egl_context;
 
-enum surface_layers_layer layer_index = SURFACE_LAYERS_LAYER_OVERLAY;
+enum surface_layers_layer layer_index = SURFACE_LAYERS_LAYER_INPUT;
 uint32_t anchor = LAYER_SURFACE_ANCHOR_NONE;
 uint32_t input_types = LAYER_SURFACE_INPUT_DEVICE_NONE;
 uint32_t exclusive_types = LAYER_SURFACE_INPUT_DEVICE_NONE;
@@ -382,8 +382,10 @@ enum surface_layers_layer parse_layer(const char *s) {
 		return SURFACE_LAYERS_LAYER_BOTTOM;
 	} else if (strcmp(s, "top") == 0) {
 		return SURFACE_LAYERS_LAYER_TOP;
-	} else if (strcmp(s, "overlay") == 0) {
-		return SURFACE_LAYERS_LAYER_OVERLAY;
+	} else if (strcmp(s, "locking") == 0) {
+		return SURFACE_LAYERS_LAYER_LOCKING;
+	} else if (strcmp(s, "input") == 0) {
+		return SURFACE_LAYERS_LAYER_INPUT;
 	}
 	fprintf(stderr, "Unknown layer name: %s\n", s);
 	exit(EXIT_FAILURE);

--- a/protocol/surface-layers.xml
+++ b/protocol/surface-layers.xml
@@ -67,12 +67,35 @@
         Fullscreen shell surfaces are typically rendered at the top layer.
         Multiple surfaces can share a single layer, and ordering within a
         single layer is undefined.
+
+        The background layer should be used by background applications. They
+        should generally anchor to all 4 sides and spawn the entire output.
+
+        The bottom layer will be shared by panels and interactive desktop
+        elements.
+        The panel would request an exclusive zone, while the desktop uses a
+        non-exclusive surface anchored to all 4 sides, leaving it to the
+        compositor to ensure they don't overlap.
+        Interactive desktop elements are e.g. quick links to open the file
+        manager on mount points, or xdg .desktop file links.
+
+        The top layer can be used to implement a quake-like terminal application.
+
+        The locking layer is supposed to support screen locking. It is placed
+        above all normal layers on purpose. It should be considerd above
+        fullscreened shell applications and is supposed to break grabs.
+
+        The input layer is intended for on-screen keyboards. On touch-only
+        devices those may have to be displayed above the locker to provide
+        password based authentication.
+        This is also explicitly above fullscrened applications.
       </description>
 
       <entry name="background" value="0"/>
       <entry name="bottom" value="1"/>
       <entry name="top" value="2"/>
-      <entry name="overlay" value="3"/>
+      <entry name="locking" value="3"/>
+      <entry name="input" value="4"/>
     </enum>
   </interface>
 
@@ -174,11 +197,20 @@
       <description summary="types of input devices">
         These flags are a bitfield and are used by set_interactive to specify
         what sorts of input the surface should interact with.
+
+        If `all` is set, the semantics change to exclude the given input devices.
+        This is roughly the same as inverting the bits in the argument,
+        but allows to match device types not yet mentioned in the protocol
+        specification the client uses, but supported by the compositor.
+
+        This allows for screen locking applications to catch all devices,
+        without a need to update for any new device type.
       </description>
       <entry name="none" value="0"/>
-      <entry name="pointer" value="1"/>
-      <entry name="keyboard" value="2"/>
-      <entry name="touch" value="4"/>
+      <entry name="all" value="1"/>
+      <entry name="pointer" value="2"/>
+      <entry name="keyboard" value="4"/>
+      <entry name="touch" value="8"/>
     </enum>
 
     <enum name="anchor" bitfield="true">

--- a/rootston/output.c
+++ b/rootston/output.c
@@ -179,7 +179,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 
 	if (remaining_layer_surfaces != NULL) {
 		render_layer_surfaces(remaining_layer_surfaces, desktop, wlr_output,
-			&now, SURFACE_LAYERS_LAYER_OVERLAY);
+			&now, SURFACE_LAYERS_LAYER_INPUT);
 	}
 
 	wlr_renderer_end(server->renderer);

--- a/types/wlr_surface_layers.c
+++ b/types/wlr_surface_layers.c
@@ -201,7 +201,7 @@ static void surface_layers_get_layer_surface(struct wl_client *client,
 	struct wlr_surface *surface = wl_resource_get_user_data(surface_resource);
 	struct wlr_output *output = wl_resource_get_user_data(output_resource);
 
-	if (layer > SURFACE_LAYERS_LAYER_OVERLAY) {
+	if (layer > SURFACE_LAYERS_LAYER_INPUT) {
 		wl_resource_post_error(resource, SURFACE_LAYERS_ERROR_INVALID_LAYER,
 			"Unknown layer");
 		return;


### PR DESCRIPTION
I split the overlay layer into an explicit locking layer and an
explicit input area layer.
This avoids ambiguous z-order for applications that should have a well
defined order.
I also added intended usecases to the documentation. Those are mainly
to set up for discussion.
It would be beneficial if everyone has a simliar model of how this
protocol should be used, so these should be informational.

I also added an "all" flag to input devices. This is intended for
session locking tools, to be able to lock all input, without having to
be updated for the mos current protocol spec with newer input devices.